### PR TITLE
GitHub Actions setup to test and build Mograsim automatically

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Checkout submodules # See https://github.com/actions/checkout#Checkout-submodules
+      shell: bash
+      run: |
+         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+         git submodule sync --recursive
+         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
This contains a basic GitHub Actions setup for Mograsim to run tests automatically without any third-party CI service. This may later be extended to continuous deployment to the eclipse update site.