### PR TITLE
Update README to use GitHub Actions Build Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [Getting Started](docs/getting_started.md)
 
 | Branch | Status |
 | ------ | ------ |
-| `master` | [![Build Status](https://travis-ci.com/Mograsim-Team/Mograsim.svg?branch=master)](https://travis-ci.com/Mograsim-Team/Mograsim) |
-| `development` | [![Build Status](https://travis-ci.com/Mograsim-Team/Mograsim.svg?branch=development)](https://travis-ci.com/Mograsim-Team/Mograsim) |
+| `master` | ![Java CI](https://github.com/MaisiKoleni/Mograsim/workflows/Java%20CI/badge.svg) |
+| `development` | ![Java CI](https://github.com/MaisiKoleni/Mograsim/workflows/Java%20CI/badge.svg?branch=development) |
 
 See [Building Mograsim](docs/building_mograsim.md)


### PR DESCRIPTION
Since we don't use Travis CI anymore and GitHub Actions is now available and already in use, we should also exchange the build status badges in the README.